### PR TITLE
Truncate floating point <advance width=…> values

### DIFF
--- a/test_data/bugfixes/Q_.glif
+++ b/test_data/bugfixes/Q_.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="Q" format="2">
+  <advance width="b0rked"/>
+  <unicode hex="0051"/>
+  <anchor x="787.2" y="688.0" name="_center"/>
+  <outline>
+    <contour>
+      <point x="712.0" y="483.2" type="line"/>
+      <point x="956.8" y="160.8" type="line"/>
+      <point x="1014.0" y="81.6" type="line"/>
+      <point x="1179.2" y="-134.0" type="line"/>
+      <point x="1409.2" y="-134.0" type="line"/>
+      <point x="1160.8" y="190.4" type="line"/>
+      <point x="1088.8" y="280.4" type="line"/>
+      <point x="933.2" y="483.2" type="line"/>
+    </contour>
+    <component base="O"/>
+  </outline>
+</glyph>

--- a/test_data/bugfixes/issue54.glif
+++ b/test_data/bugfixes/issue54.glif
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="iecyrillic" format="2">
+  <advance width="1143.6666666666667"/>
+  <unicode hex="0435"/>
+  <anchor x="503.3333333333333" y="0.0" name="bottom"/>
+  <anchor x="506.6666666666667" y="0.0" name="cedilla"/>
+  <anchor x="972.3333333333334" y="218.0" name="ogonek"/>
+  <anchor x="719.3333333333334" y="1304.0" name="top"/>
+  <outline>
+    <component base="e"/>
+  </outline>
+</glyph>

--- a/tests/bugfixes/issue54.rs
+++ b/tests/bugfixes/issue54.rs
@@ -1,0 +1,13 @@
+use glifparser;
+
+#[super::test]
+fn test_bug_fixed() {
+    let gliffn = "test_data/bugfixes/issue54.glif";
+    log::trace!("{}", gliffn);
+    let glif: glifparser::Glif<()> = glifparser::glif::read_from_filename(gliffn).unwrap();
+    assert_eq!(glif.width, Some(1143));
+    let gliffn = "test_data/bugfixes/Q_.glif";
+    log::trace!("{}", gliffn);
+    let glif: Result<glifparser::Glif<()>, glifparser::error::GlifParserError> = glifparser::glif::read_from_filename(gliffn);
+    assert!(glif.is_err());
+}

--- a/tests/bugfixes/mod.rs
+++ b/tests/bugfixes/mod.rs
@@ -1,0 +1,3 @@
+use test_log::{self, test};
+
+mod issue54;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,1 @@
+mod bugfixes;


### PR DESCRIPTION
Closes #54 (GitHub).
Works around rsms/inter#508 (GitHub).

Test added for №54:
```
[2022-10-08T11:27:29Z TRACE r#mod::bugfixes::issue54] test_data/bugfixes/issue54.glif
[2022-10-08T11:27:29Z WARN  glifparser::glif::read] Floating point value given as <advance> width — OpenType `hmtx` / `vmtx` will truncate it, so we do too!
[2022-10-08T11:27:29Z DEBUG glifparser::outline] Outline only has corners; Outline<PD> type will treat it as a cubic. 
[2022-10-08T11:27:29Z TRACE r#mod::bugfixes::issue54] test_data/bugfixes/Q_.glif
[2022-10-08T11:27:29Z TRACE glifparser::glif::read] <advance> parsing as int rose ParseIntError { kind: InvalidDigit }
test bugfixes::issue54::test_bug_fixed ... ok
```