### PR TITLE
Make it possible to build without skia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ glifimage = ["image"]
 glifserde = ["serde", "kurbo/serde", "integer_or_float/serde", "plist/default"]
 default = ["glifimage", "glifserde"]
 skia = ["default", "skia-safe"]
-mfek = ["default", "skia"]
+mfek = ["default"]
 more-image-formats = ["image/gif", "image/jpeg", "image/webp", "image/bmp", "image/tiff"]
 more-iof = ["integer_or_float/num-traits"]
 

--- a/src/glif/mfek.rs
+++ b/src/glif/mfek.rs
@@ -2,17 +2,19 @@ use std::collections::HashSet;
 use std::path as stdpath;
 use std::{fmt::Display, str::FromStr};
 
-use skia_safe::{self as skia, Path};
 use kurbo::Affine;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "skia")]
+use skia_safe::{self as skia, Path};
 
 use crate::anchor::Anchor;
 use crate::component::{ComponentRect, GlifComponents};
 use crate::error::{mfek::*, GlifParserError};
 use crate::glif::Glif;
 use crate::guideline::Guideline;
-use crate::outline::{Outline, Contour, OutlineType};
+#[cfg(feature = "skia")]
 use crate::outline::skia::{SkiaPaths, SkiaPointTransforms, ToSkiaPath, ToSkiaPaths};
+use crate::outline::{Contour, Outline, OutlineType};
 use crate::point::{Point, PointData, PointType};
 
 #[macro_use] pub mod layer;


### PR DESCRIPTION
This makes Skia an optional dependency in the MFEK feature. This is required for building math.rlib without the Skia dependency, of which another PR soon...