### PR TITLE
Add getter and setter for smooth property of MFEKPointCommon

### DIFF
--- a/src/glif/mfek/point/hyper.rs
+++ b/src/glif/mfek/point/hyper.rs
@@ -128,6 +128,14 @@ impl<PD: PointData> MFEKPointCommon<PD> for HyperPoint<PD> {
             WhichHandle::B => {self.b = Handle::Colocated}
         }
     }
+
+    fn get_smooth(&self) -> Option<bool> {
+        None
+    }
+
+    fn set_smooth(&mut self, _: bool) {
+        // Do nothing
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Default)]

--- a/src/glif/mfek/point/mod.rs
+++ b/src/glif/mfek/point/mod.rs
@@ -21,6 +21,8 @@ pub trait MFEKPointCommon<PD: PointData>: DynClone {
     fn get_position(&self) -> (f32, f32);
     fn set_position(&mut self, x: f32, y:f32);
     fn set_position_no_handles(&mut self, x: f32, y:f32);
+    fn get_smooth(&self) -> Option<bool>;
+    fn set_smooth(&mut self, smooth: bool);
     fn cubic(&self) -> Option<&Point<PD>>;
     fn quad(&self) -> Option<&QPoint<PD>>;
     fn hyper(&self) -> Option<&HyperPoint<PD>>;
@@ -136,5 +138,13 @@ impl<PD: PointData> MFEKPointCommon<PD> for Point<PD> {
             WhichHandle::A => self.a = Handle::Colocated,
             WhichHandle::B => self.b = Handle::Colocated,
         }
+    }
+
+    fn get_smooth(&self) -> Option<bool> {
+        Some(self.smooth)
+    }
+
+    fn set_smooth(&mut self, smooth: bool) {
+        self.smooth = smooth;
     }
 }

--- a/src/glif/mfek/point/quad.rs
+++ b/src/glif/mfek/point/quad.rs
@@ -124,4 +124,12 @@ impl<PD: PointData> MFEKPointCommon<PD> for QPoint<PD> {
             self.a = Handle::Colocated
         }
     }
+
+    fn get_smooth(&self) -> Option<bool> {
+        None
+    }
+
+    fn set_smooth(&mut self, _: bool) {
+        // Do nothing
+    }
 }


### PR DESCRIPTION
Since the smooth property is used in certain functions in the glyph editor, having a getter/setter in the trait's API makes accessing this property more ergonomic. For hyper and quad the functions are essentially noops, and for cubic there's a very simple implementation that just directly accesses the smooth property